### PR TITLE
Add a check into BufferAllocation_2.c to ensure the addition of paddi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ FreeRTOS+TCP V2.3.2 [source code](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/
 ### Getting help
 If you have any questions or need assistance troubleshooting your FreeRTOS project, we have an active community that can help on the [FreeRTOS Community Support Forum](https://forums.freertos.org). Please also refer to [FAQ](http://www.freertos.org/FAQHelp.html) for frequently asked questions.
 
-Also see the [Submitting a bugs/feature request](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/master/CONTRIBUTING.md#submitting-a-bugsfeature-request) section of CONTRIBUTING.md for more details.
+Also see the [Submitting a bugs/feature request](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/.github/CONTRIBUTING.md#submitting-a-bugsfeature-request) section of CONTRIBUTING.md for more details.
 
 ## Cloning this repository
 This repository uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring in dependent components.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -411,6 +411,11 @@
 
 #ifndef ipconfigNETWORK_MTU
     #define ipconfigNETWORK_MTU    1500
+#else
+    #if ipconfigNETWORK_MTU > ( SIZE_MAX >> 1 )
+        #undef ipconfigNETWORK_MTU
+        #define ipconfigNETWORK_MTU    ( SIZE_MAX >> 1 )
+    #endif
 #endif
 
 #ifndef ipconfigTCP_MSS

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -226,7 +226,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
     NetworkBufferDescriptor_t * pxReturn = NULL;
     size_t uxCount;
 
-    if( xNetworkBufferSemaphore != NULL )
+    if( ( xRequestedSizeBytes <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) && ( xNetworkBufferSemaphore != NULL ) )
     {
         /* If there is a semaphore available, there is a network buffer available. */
         if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )


### PR DESCRIPTION
…ng to the allocation size does not cause an integer overflow (#325)

* Add a check into BufferAllocation_2.c to ensure the addition of padding to the allocation size does not cause an integer overflow

Updated a broken link in README.md

In BufferAllocation_2.c
(https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/portable/BufferManagement/BufferAllocation_2.c),
there is an unchecked possible addition overflow when calculating the size of
the block of memory to be allocated for a network buffer that could result in
the size overflowing and the allocation returning success but allocating only
a fraction of the memory asked for. With default settings, this would only
occur when attempting to allocate within 12 bytes of 4 GB. Thanks to
Bernard Lebel (RMDS Innovation) for reporting this potential issue.

Signed-off-by: Aniruddha Kanhere <60444055+AniruddhaKanhere@users.noreply.github.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
