### PR TITLE
IPv6/multi: Add a check into BufferAllocation_2.c to ensure the addit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Additionally, for FreeRTOS-Plus-TCP source code organization refer to the [Docum
 ### Getting help
 If you have any questions or need assistance troubleshooting your FreeRTOS project, we have an active community that can help on the [FreeRTOS Community Support Forum](https://forums.freertos.org). Please also refer to [FAQ](http://www.freertos.org/FAQHelp.html) for frequently asked questions.
 
-Also see the [Submitting a bugs/feature request](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/master/CONTRIBUTING.md#submitting-a-bugsfeature-request) section of CONTRIBUTING.md for more details.
+Also see the [Submitting a bugs/feature request](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/.github/CONTRIBUTING.md#submitting-a-bugsfeature-request) section of CONTRIBUTING.md for more details.
 
 ## Cloning this repository
 This repository uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring in dependent components.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -414,6 +414,11 @@
 
 #ifndef ipconfigNETWORK_MTU
     #define ipconfigNETWORK_MTU    1500U
+#else
+    #if ipconfigNETWORK_MTU > ( SIZE_MAX >> 1 )
+        #undef ipconfigNETWORK_MTU
+        #define ipconfigNETWORK_MTU    ( SIZE_MAX >> 1 )
+    #endif
 #endif
 
 #ifndef ipconfigTCP_MSS

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -231,7 +231,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
     size_t uxCount;
     size_t uxByteCount = uxRequestedSizeBytes; /* To avoid lint complain: function parameter modified [MISRA 2012 Rule 17.8, advisory]. */
 
-    if( xNetworkBufferSemaphore != NULL )
+    if( ( uxRequestedSizeBytes <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) && ( xNetworkBufferSemaphore != NULL ) )
     {
         if( ( uxByteCount != 0U ) && ( uxByteCount < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
         {


### PR DESCRIPTION
…ion of padding to the allocation size does not cause an integer overflow (#326)

* Add a check into BufferAllocation_2.c to ensure the addition of padding
to the allocation size does not cause an integer overflow

* Fix a typo

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
